### PR TITLE
fix: select by channel's schedule using snake case

### DIFF
--- a/app/static/historicalPlot.js
+++ b/app/static/historicalPlot.js
@@ -41,8 +41,9 @@ function updateHistoricalPlot(convertSelectedBroadcaster, startedAt) {
                     const timePart = parts[1];
                     const formattedDate = `${datePart}T${timePart}+08:00`;
                     console.log("formattedDate:", formattedDate);
-
-                    updateHistoricalPlot(selectBroadcaster, formattedDate);
+                    
+                    // use convertSelectedBroadcaster to select by snake case name
+                    updateHistoricalPlot(convertSelectedBroadcaster, formattedDate);
                 });
 
                 scheduleHeader.appendChild(startedAt);


### PR DESCRIPTION
In historicalPlot.js, turn to use 'convertSelectedBroadcaster' in line 67: updateHistoricalPlot(convertSelectedBroadcaster, formattedDate);